### PR TITLE
fix: center hero subtitle on mobile

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -83,6 +83,7 @@ const { t } = Astro.props;
     letter-spacing: 0.2em;
     text-transform: uppercase;
     color: rgba(255, 255, 255, 0.45);
+    text-align: center;
     opacity: 0;
     animation: fade-up 0.6s var(--ease-smooth) 0.55s forwards;
   }


### PR DESCRIPTION
Fixes #2

Added `text-align: center` to `.hero__title` in `src/components/Hero.astro`. The subtitle was left-aligned on mobile because the `<p>` element had no explicit text alignment, causing wrapped text to fall back to the browser default (left). Desktop layout is unchanged.

Generated with [Claude Code](https://claude.ai/code)