### PR TITLE
fix: use Claude brand color for certification badge icon

### DIFF
--- a/src/components/CertificationBadge.astro
+++ b/src/components/CertificationBadge.astro
@@ -16,7 +16,7 @@ const { t } = Astro.props;
 >
   <img
     class="cert-badge__icon"
-    src="https://cdn.simpleicons.org/claude/E8FF47"
+    src="https://cdn.simpleicons.org/claude"
     alt=""
     aria-hidden="true"
     width="12"


### PR DESCRIPTION
Fix the Claude icon in CertificationBadge.astro to use Claude's official brand color instead of the site's accent color.

Removed the hardcoded `E8FF47` color override from the simpleicons CDN URL so the icon renders with Claude's own brand color.

Closes #13

Generated with [Claude Code](https://claude.ai/code)